### PR TITLE
Mean now handle iteratively instead of summing to overflow

### DIFF
--- a/Sources/StatKit/Descriptive Statistics/Central Tendency/MeanType.swift
+++ b/Sources/StatKit/Descriptive Statistics/Central Tendency/MeanType.swift
@@ -25,7 +25,7 @@ extension MeanType {
                                                              in collection: U) -> Double {
     switch self {
       case .arithmetic:
-        return collection.sum(over: variable).realValue / Double(collection.count)
+        return collection.average(over: variable)
       
       #if canImport(Darwin) || canImport(Glibc)
       case .geometric:

--- a/Sources/StatKit/Descriptive Statistics/Central Tendency/MeanType.swift
+++ b/Sources/StatKit/Descriptive Statistics/Central Tendency/MeanType.swift
@@ -25,7 +25,11 @@ extension MeanType {
                                                              in collection: U) -> Double {
     switch self {
       case .arithmetic:
-        return collection.average(over: variable)
+        return zip(collection, 1...collection.count)
+          .reduce(into: 0.0) { result, zip in
+            let (element, count) = zip
+            result += (element[keyPath: variable].realValue - result) / count.realValue
+      }
       
       #if canImport(Darwin) || canImport(Glibc)
       case .geometric:

--- a/Sources/StatKit/Descriptive Statistics/Summation/Summation.swift
+++ b/Sources/StatKit/Descriptive Statistics/Summation/Summation.swift
@@ -10,4 +10,21 @@ extension Sequence {
       result += element[keyPath: variable]
     }
   }
+    /// Calculates the average of all contained elements.
+    /// - parameter variable: The variable over which to calculate the average.
+    /// - returns: The average of the variable in the sequence.
+    /// The time complexity of this method is O(n).
+    @inlinable
+    public func average<T>(over variable: KeyPath<Element, T>) -> Double
+    where T: ConvertibleToReal
+    {
+        var avg = 0.0
+        var t = 1.0
+          for x in self {
+            let value = x[keyPath: variable]
+            avg += (value.realValue - avg) / t
+            t += 1
+          }
+          return avg
+    }
 }

--- a/Sources/StatKit/Descriptive Statistics/Summation/Summation.swift
+++ b/Sources/StatKit/Descriptive Statistics/Summation/Summation.swift
@@ -10,21 +10,4 @@ extension Sequence {
       result += element[keyPath: variable]
     }
   }
-    /// Calculates the average of all contained elements.
-    /// - parameter variable: The variable over which to calculate the average.
-    /// - returns: The average of the variable in the sequence.
-    /// The time complexity of this method is O(n).
-    @inlinable
-    public func average<T>(over variable: KeyPath<Element, T>) -> Double
-    where T: ConvertibleToReal
-    {
-        var avg = 0.0
-        var t = 1.0
-          for x in self {
-            let value = x[keyPath: variable]
-            avg += (value.realValue - avg) / t
-            t += 1
-          }
-          return avg
-    }
 }

--- a/Tests/StatKitTests/Descriptive Statistics Tests/AveragesTests.swift
+++ b/Tests/StatKitTests/Descriptive Statistics Tests/AveragesTests.swift
@@ -11,6 +11,14 @@ final class AveragesTests: XCTestCase {
     
     XCTAssertEqual(calculatedMean, expectedMean)
   }
+  func testBigNumberIntegerArithmeticMean() {
+    let value = Int.max / 9
+    let bigIntArray = [9*value, 6*value, 3*value]
+    let calculateMean = bigIntArray.mean(of: \.self)
+    let expectedMean = Double(value*6)
+    print(expectedMean, calculateMean, bigIntArray)
+    XCTAssertEqual(calculateMean, expectedMean)
+  }
   
   func testFloatingPointArithmeticMean() {
     let fpArray = [1.5, 2.5, 3.5, 4.5, 5.5]

--- a/Tests/StatKitTests/Descriptive Statistics Tests/AveragesTests.swift
+++ b/Tests/StatKitTests/Descriptive Statistics Tests/AveragesTests.swift
@@ -11,13 +11,14 @@ final class AveragesTests: XCTestCase {
     
     XCTAssertEqual(calculatedMean, expectedMean)
   }
+
   func testBigNumberIntegerArithmeticMean() {
     let value = Int.max / 9
-    let bigIntArray = [9*value, 6*value, 3*value]
+    let bigIntArray = [9 * value, 6 * value, 3 * value]
     let calculateMean = bigIntArray.mean(of: \.self)
-    let expectedMean = Double(value*6)
-    print(expectedMean, calculateMean, bigIntArray)
-    XCTAssertEqual(calculateMean, expectedMean)
+    let expectedMean = Double(value * 6)
+    
+    XCTAssertEqual(calculateMean, expectedMean, accuracy: 0.00001)
   }
   
   func testFloatingPointArithmeticMean() {

--- a/Tests/StatKitTests/XCTestManifests.swift
+++ b/Tests/StatKitTests/XCTestManifests.swift
@@ -16,6 +16,7 @@ extension AveragesTests {
         ("testFloatingPointMedian", testFloatingPointMedian),
         ("testIntArrayMode", testIntArrayMode),
         ("testIntegerArithmeticMean", testIntegerArithmeticMean),
+        ("testBigNumberIntegerArithmeticMean",testBigNumberIntegerArithmeticMean),
         ("testIntegerGeometricMean", testIntegerGeometricMean),
         ("testIntMedian", testIntMedian),
         ("testObjectArithmeticMean", testObjectArithmeticMean),

--- a/Tests/StatKitTests/XCTestManifests.swift
+++ b/Tests/StatKitTests/XCTestManifests.swift
@@ -16,7 +16,7 @@ extension AveragesTests {
         ("testFloatingPointMedian", testFloatingPointMedian),
         ("testIntArrayMode", testIntArrayMode),
         ("testIntegerArithmeticMean", testIntegerArithmeticMean),
-        ("testBigNumberIntegerArithmeticMean",testBigNumberIntegerArithmeticMean),
+        ("testBigNumberIntegerArithmeticMean", testBigNumberIntegerArithmeticMean),
         ("testIntegerGeometricMean", testIntegerGeometricMean),
         ("testIntMedian", testIntMedian),
         ("testObjectArithmeticMean", testObjectArithmeticMean),


### PR DESCRIPTION
I recently got this issue for summing may overflow. This may cause fatal. I just add the functionality randomly, maybe you want to rearrange files again.