### PR TITLE
Create .spi.yml to host documentation

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+  - documentation_targets: [StatKit]


### PR DESCRIPTION
You mention in your Readme that users can generate and view DocC documentation locally.

Adding this file will make your docs available online at the [Swift Package Index](https://swiftpackageindex.com), if you’re interested in hosting them there :)

More info here: https://blog.swiftpackageindex.com/posts/auto-generating-auto-hosting-and-auto-updating-docc-documentation/