### PR TITLE
refactor(kendall-tau): drop ConvertibleToReal constraint from kendallTau

### DIFF
--- a/Sources/StatKit/Descriptive Statistics/Association/Correlation.swift
+++ b/Sources/StatKit/Descriptive Statistics/Association/Correlation.swift
@@ -125,8 +125,8 @@ public extension Collection {
     and Y: KeyPath<Element, U>,
     variant: KendallTauVariant = .b
   ) -> Double
-  where T: Comparable & Hashable & ConvertibleToReal,
-        U: Comparable & Hashable & ConvertibleToReal
+  where T: Comparable & Hashable,
+        U: Comparable & Hashable
   {
   let tiesX = self.countTieRanks(of: X)
   let tiesY = self.countTieRanks(of: Y)

--- a/Tests/StatKitTests/Descriptive Statistics Tests/Association Tests/KendallTauTests.swift
+++ b/Tests/StatKitTests/Descriptive Statistics Tests/Association Tests/KendallTauTests.swift
@@ -1,6 +1,14 @@
 import Testing
 import StatKit
 
+private enum EducationLevel: Comparable, Hashable {
+  case highSchool, bachelor, master, doctorate
+}
+
+private enum IncomeLevel: Comparable, Hashable {
+  case low, middle, high
+}
+
 @Suite("Kendall Tau Tests", .tags(.correlationCoefficient))
 struct KendallTauTests {
   @Test("Monotonically increasing data yields a correlation of 1", arguments: KendallTauVariant.allCases)
@@ -128,6 +136,25 @@ struct KendallTauTests {
     ]
 
     #expect(data.kendallTau(of: \.x, and: \.y, variant: .b).isNaN)
+  }
+
+  @Test("Ordinal data produces a valid correlation")
+  func ordinalData() async {
+    let data: [(education: EducationLevel, income: IncomeLevel)] = [
+      (.highSchool, .low), (.highSchool, .low), (.highSchool, .middle),
+      (.bachelor, .low), (.bachelor, .middle), (.bachelor, .middle), (.bachelor, .high),
+      (.master, .middle), (.master, .high), (.master, .high),
+      (.doctorate, .high), (.doctorate, .high),
+    ]
+
+    #expect(
+      data.kendallTau(of: \.education, and: \.income, variant: .a)
+        .isApproximatelyEqual(to: 0.5151515152, absoluteTolerance: 1e-6)
+    )
+    #expect(
+      data.kendallTau(of: \.education, and: \.income, variant: .b)
+        .isApproximatelyEqual(to: 0.6812273147, absoluteTolerance: 1e-6)
+    )
   }
 
   @Test("Correlation on empty collection is undefined", arguments: KendallTauVariant.allCases)


### PR DESCRIPTION
kendallTau only requires ordinal data — Comparable and Hashable are sufficient. All arithmetic inside the function operates on Int values derived from counts, not on T or U directly. Removing ConvertibleToReal makes the API consistent with that requirement.

Also adds an ordinal-data test using non-numeric enum types to exercise the relaxed constraint.

Closes #161