### PR TITLE
fix(exponential-distribution): correct sign in log-space pdf branch

### DIFF
--- a/Sources/StatKit/Descriptive Statistics/Distribution/Continuous/ExponentialDistribution.swift
+++ b/Sources/StatKit/Descriptive Statistics/Distribution/Continuous/ExponentialDistribution.swift
@@ -22,7 +22,7 @@ public struct ExponentialDistribution: ContinuousDistribution, UnivariateDistrib
         return logarithmic ? -.infinity : 0
         
       default:
-        return logarithmic ? .log(rate) + rate * x : rate * .exp(-rate * x)
+        return logarithmic ? .log(rate) - rate * x : rate * .exp(-rate * x)
     }
   }
   

--- a/Tests/StatKitTests/Descriptive Statistics Tests/Distribution Tests/Continuous/ExponentialDistributionTests.swift
+++ b/Tests/StatKitTests/Descriptive Statistics Tests/Distribution Tests/Continuous/ExponentialDistributionTests.swift
@@ -6,7 +6,7 @@ struct ExponentialDistributionTests {
   @Test(
     "Valid distribution parameters return correct mean",
     arguments: [
-      (1.0, 1.0),
+      (1.0,  1.0),
       (57.0, 0.0175438),
     ]
   )
@@ -18,7 +18,7 @@ struct ExponentialDistributionTests {
   @Test(
     "Valid distribution parameters return correct variance",
     arguments: [
-      (1.0, 1.0),
+      (1.0,  1.0),
       (57.0, 0.000307787),
     ]
   )
@@ -30,7 +30,7 @@ struct ExponentialDistributionTests {
   @Test(
     "Valid distribution parameters return correct skewness",
     arguments: [
-      (1.0, 2.0),
+      (1.0,  2.0),
       (57.0, 2.0),
     ]
   )
@@ -42,7 +42,7 @@ struct ExponentialDistributionTests {
   @Test(
     "Valid distribution parameters return correct excess kurtosis",
     arguments: [
-      (1.0, 6.0),
+      (1.0,  6.0),
       (57.0, 6.0),
     ]
   )
@@ -54,12 +54,12 @@ struct ExponentialDistributionTests {
   @Test(
     "Valid distribution parameters return correct CDF value",
     arguments: [
-      (1.0, 1.0, 0.63212),
-      (1.0, 0.0, 0.0),
-      (1.0, 0.4, 0.32968),
-      (57.0, 0.1, 0.9966540),
+      (1.0,  1.0,  0.6321206),
+      (1.0,  0.0,  0.0),
+      (1.0,  0.4,  0.3296800),
+      (57.0, 0.1,  0.9966540),
       (57.0, -8.0, 0.0),
-      (57.0, 0.0, 0.0),
+      (57.0, 0.0,  0.0),
     ]
   )
   func validInputReturnsCorrectCDF(rate: Double, x: Double, expectedCDF: Double) async throws {
@@ -70,12 +70,12 @@ struct ExponentialDistributionTests {
   @Test(
     "Valid distribution parameters return correct log CDF value",
     arguments: [
-      (1.0, 1.0, -0.4586751),
-      (1.0, 0.0, -Double.infinity),
-      (1.0, 0.4, -1.1096329),
-      (57.0, 0.1, -0.003351576),
+      (1.0,  1.0,  -0.4586751),
+      (1.0,  0.0,  -Double.infinity),
+      (1.0,  0.4,  -1.1096329),
+      (57.0, 0.1,  -0.003351576),
       (57.0, -8.0, -Double.infinity),
-      (57.0, 0.0, -Double.infinity),
+      (57.0, 0.0,  -Double.infinity),
     ]
   )
   func validInputReturnsCorrectLogCDF(rate: Double, x: Double, expectedLogCDF: Double) async throws {
@@ -83,14 +83,97 @@ struct ExponentialDistributionTests {
     #expect(cdf.isApproximatelyEqual(to: expectedLogCDF, absoluteTolerance: 1e-6))
   }
 
+  @Test(
+    "Valid distribution parameters return correct PDF value",
+    arguments: [
+      (1.0,  0.0,  1.0),
+      (1.0,  0.4,  0.6703200),
+      (1.0,  1.0,  0.3678794),
+      (1.0,  -1.0, 0.0),
+      (57.0, 0.0,  57.0),
+      (57.0, 0.1,  0.190720031),
+    ]
+  )
+  func validInputReturnsCorrectPDF(rate: Double, x: Double, expectedPDF: Double) async throws {
+    let pdf = ExponentialDistribution(rate: rate).pdf(x: x)
+    #expect(pdf.isApproximatelyEqual(to: expectedPDF, absoluteTolerance: 1e-6))
+  }
+
+  @Test(
+    "Valid distribution parameters return correct log PDF value",
+    arguments: [
+      (1.0,  0.0,   0.0),
+      (1.0,  0.4,  -0.4),
+      (1.0,  1.0,  -1.0),
+      (1.0,  -1.0, -Double.infinity),
+      (57.0, 0.0,   4.043051),
+      (57.0, 0.1,  -1.656949),
+    ]
+  )
+  func validInputReturnsCorrectLogPDF(rate: Double, x: Double, expectedLogPDF: Double) async throws {
+    let pdf = ExponentialDistribution(rate: rate).pdf(x: x, logarithmic: true)
+    #expect(pdf.isApproximatelyEqual(to: expectedLogPDF, absoluteTolerance: 1e-6))
+  }
+
+  @Test(
+    "PDF at +infinity returns zero",
+    arguments: [1.0, 57.0]
+  )
+  func pdfAtInfinityIsZero(rate: Double) async throws {
+    #expect(ExponentialDistribution(rate: rate).pdf(x: .infinity) == 0)
+  }
+
+  @Test(
+    "Log PDF at +infinity returns -infinity",
+    arguments: [1.0, 57.0]
+  )
+  func logPDFAtInfinityIsNegativeInfinity(rate: Double) async throws {
+    #expect(ExponentialDistribution(rate: rate).pdf(x: .infinity, logarithmic: true) == -.infinity)
+  }
+
+  @Test(
+    "CDF at ±infinity returns correct value",
+    arguments: [1.0, 57.0]
+  )
+  func cdfAtInfinityIsCorrect(rate: Double) async throws {
+    let distribution = ExponentialDistribution(rate: rate)
+    #expect(distribution.cdf(x: -.infinity) == 0)
+    #expect(distribution.cdf(x: .infinity) == 1)
+  }
+
+  @Test(
+    "Log CDF at ±infinity returns correct value",
+    arguments: [1.0, 57.0]
+  )
+  func logCDFAtInfinityIsCorrect(rate: Double) async throws {
+    let distribution = ExponentialDistribution(rate: rate)
+    #expect(distribution.cdf(x: -.infinity, logarithmic: true) == -.infinity)
+    #expect(distribution.cdf(x: .infinity, logarithmic: true) == 0)
+  }
+
+#if swift(>=6.2)
+  @Test("Non-positive rate triggers a precondition failure")
+  func nonPositiveRateTriggersPreconditionFailure() async {
+    await #expect(processExitsWith: .failure) {
+      _ = ExponentialDistribution(rate: 0)
+    }
+  }
+
+  @Test("Non-positive sample count triggers a precondition failure")
+  func nonPositiveSampleCountTriggersPreconditionFailure() async {
+    await #expect(processExitsWith: .failure) {
+      _ = ExponentialDistribution(rate: 1).sample(0)
+    }
+  }
+#endif
+
   @Test("Sampling from a distribution returns correct proportions")
   func testSampling() async throws {
-    let numberOfSamples = 1000000
+    let numberOfSamples = 1_000_000
     let distribution = ExponentialDistribution(rate: 0.2)
     let samples = distribution.sample(numberOfSamples)
 
     var proportions = samples.reduce(into: [Int: Double]()) { result, number in result[Int(number), default: 0] += 1 }
-
     for key in proportions.keys { proportions[key]? /= Double(numberOfSamples) }
 
     #expect(samples.count == numberOfSamples)


### PR DESCRIPTION
The logarithmic branch used `+ rate * x` instead of `- rate * x`, causing log pdf to grow with x rather than decay. The correct identity is log pdf(x) = log(λ) − λx.

Expanded the test suite to cover pdf (previously untested), log pdf (which directly exercises the fixed branch), boundary values at ±infinity, and precondition failure tests, aligning the suite with LogisticDistributionTests.

Fixes: #175